### PR TITLE
Dropdown z-index + header parity with MFEs

### DIFF
--- a/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/lms/static/sass/partials/lms/theme/_extras.scss
@@ -10,3 +10,7 @@
 @import 'custom_overrides/_buttons.scss';
 @import 'custom_overrides/_header.scss';
 @import 'custom_overrides/_footer.scss';
+
+.dropdown-user-menu {
+    z-index: 11;
+}

--- a/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/lms/static/sass/partials/lms/theme/_extras.scss
@@ -12,5 +12,24 @@
 @import 'custom_overrides/_footer.scss';
 
 .dropdown-user-menu {
-    z-index: 11;
+    z-index: 11 !important;
+}
+
+// Copied from edx-platform to correct discrepancy between authenticated and
+// non-authenticated headers, as well as with MFE header
+// Note: JS applies this class to nav items in `/templates/footer.html`
+.tab-nav-link {
+    font-size: em(16);
+    color: $gray;
+    padding: 5px 25px 23px;
+    display: inline-block;
+    border-bottom: 4px solid transparent;
+
+    &:hover,
+    &:focus {
+        border-bottom: 4px solid $primary;
+    }
+}
+.global-header {
+    padding-bottom: 0;
 }

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -2,6 +2,14 @@
 
 <%namespace name='static' file='/static_content.html'/>
 
+<%block name="js_extra">
+  <script>
+    var nav = document.querySelector("nav.nav-links");
+    var links = nav.querySelectorAll("a");
+    links.forEach(link => link.classList.add("tab-nav-link"));
+  </script>
+</%block>
+
 
 <span class="campus-buildings"></span>
 <footer class="m-footer">


### PR DESCRIPTION
### Fixes two UXR findings:

https://trello.com/c/WdPmKISK/443-under-the-discover-new-tab-the-drop-down-menu-is-covered-by-the-search-filter-when-the-screen-size-is-small
Applies a higher-value z-index than the filters section in the edX discovery dashboard.

https://trello.com/c/gemDQXow/436-explore-courses-button-lacks-visual-cues-to-indicate-its-interactivity-making-it-unclear-that-it-is-clickable
Modifies the LMS header to match the MFE header (height and button hover state)