### PR TITLE
django4.0 compatibility changes

### DIFF
--- a/lms/templates/courseware/course_about_sidebar_header.html
+++ b/lms/templates/courseware/course_about_sidebar_header.html
@@ -3,7 +3,7 @@
 <%!
 import six
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.urls import reverse
 from django.conf import settings
 from six import text_type


### PR DESCRIPTION
Changed from `django.utils.translation import ugettext as _ ` to `from django.utils.translation import gettext as _` to be compatible with Django 4.0